### PR TITLE
Update urlOrFile return type for clarity

### DIFF
--- a/src/utils/forms/index.ts
+++ b/src/utils/forms/index.ts
@@ -1,4 +1,4 @@
 import { CompositionFile, PrimitiveType } from 'constant'
 
-export const urlOrFile = (eitherBlobOrString: CompositionFile): string =>
+export const urlOrFile = (eitherBlobOrString: CompositionFile): 'url' | 'file' =>
   typeof eitherBlobOrString === PrimitiveType.string ? 'url' : 'file'


### PR DESCRIPTION
changes `urlOrFile` return type to `'url' | 'file'` for clarity