### PR TITLE
only validate options for filters with options

### DIFF
--- a/src/features/videos/composition/index.ts
+++ b/src/features/videos/composition/index.ts
@@ -101,7 +101,7 @@ export class Composition implements CompositionInterface {
     }
   }
 
-  public [CompositionMethod.addFilter](options: FilterLayer): Filter | undefined {
+  public [CompositionMethod.addFilter](options?: FilterLayer): Filter | undefined {
     try {
       validateAddFilter(options)
 

--- a/src/features/videos/video/index.ts
+++ b/src/features/videos/video/index.ts
@@ -29,7 +29,7 @@ export class Video extends Mixin(Audio, VisualMedia) {
     options,
   }: {
     filterName: FilterName
-    options: FilterOptions[FilterName]
+    options?: FilterOptions[FilterName]
   }): Video | void {
     try {
       validateFilter(VideoMethod.setFilter, LayerAttribute.filter, { filterName, options }, true)

--- a/src/utils/video/filters/filters.test.ts
+++ b/src/utils/video/filters/filters.test.ts
@@ -29,6 +29,19 @@ describe('validateFilter', () => {
     describe('when a valid filter `filterName` is provided', () => {
       const filterName = FilterName.brightness
 
+      it('throws the correct error string when no filter `options` are provided', () => {
+        expect(() => validateFilter(callerName, fieldName, { filterName, options: undefined }, true)).toThrow(
+          new Error(
+            ValidationErrorText.MUST_BE_TYPE(
+              callerName,
+              ValidationErrorText.SUB_FIELD(fieldName, FilterAttribute.options),
+              undefined,
+              JSON.stringify(FilterOptionTypes[filterName])
+            )
+          )
+        )
+      })
+
       it('throws the correct error string when invalid filter `options` are provided', () => {
         expect(() => validateFilter(callerName, fieldName, { filterName, options: options as any }, true)).toThrow(
           new Error(
@@ -40,6 +53,12 @@ describe('validateFilter', () => {
             )
           )
         )
+      })
+
+      it('does not throw an error when no options are passed for a filter that does not require options', () => {
+        const filterName = FilterName.fadeOut
+
+        expect(() => validateFilter(callerName, fieldName, { filterName, options: undefined }, true)).not.toThrow()
       })
     })
   })

--- a/src/utils/video/filters/index.ts
+++ b/src/utils/video/filters/index.ts
@@ -58,7 +58,7 @@ export const validateFilter = (
     }
   }
 
-  if (isFilterNameValid && !filterValidators[filterName](options)) {
+  if (isFilterNameValid && filterName in FilterOptionTypes && !filterValidators[filterName](options)) {
     const message = ValidationErrorText.MUST_BE_TYPE(
       callerName,
       ValidationErrorText.SUB_FIELD(fieldName, FilterAttribute.options),


### PR DESCRIPTION
make `options` an optional field in `addFilter` and `setFilter` and only attempt to validate options at runtime for filters that require options