### PR TITLE
fix: use string literals instead of enums for alignment and waveform …

### DIFF
--- a/src/constant/video/layers.ts
+++ b/src/constant/video/layers.ts
@@ -42,25 +42,27 @@ export enum LayerType {
   waveform = 'waveform',
 }
 
-export enum LayerHorizontalAlignmentValue {
-  center = 'center',
-  left = 'left',
-  right = 'right',
-}
-export type LayerHorizontalAlignment =
-  | LayerHorizontalAlignmentValue.left
-  | LayerHorizontalAlignmentValue.center
-  | LayerHorizontalAlignmentValue.right
+const center = 'center'
+const left = 'left'
+const right = 'right'
 
-export enum LayerVerticalAlignmentValue {
-  bottom = 'bottom',
-  middle = 'middle',
-  top = 'top',
+export const LayerHorizontalAlignmentValue: Record<string, LayerHorizontalAlignment> = {
+  center,
+  left,
+  right,
 }
-export type LayerVerticalAlignment =
-  | LayerVerticalAlignmentValue.bottom
-  | LayerVerticalAlignmentValue.middle
-  | LayerVerticalAlignmentValue.top
+export type LayerHorizontalAlignment = typeof center | typeof left | typeof right
+
+const bottom = 'bottom'
+const middle = 'middle'
+const top = 'top'
+
+export const LayerVerticalAlignmentValue: Record<string, LayerVerticalAlignment> = {
+  bottom,
+  middle,
+  top,
+}
+export type LayerVerticalAlignment = typeof bottom | typeof middle | typeof top
 
 export enum LayerFormatValue {
   fill = 'fill',
@@ -68,12 +70,6 @@ export enum LayerFormatValue {
   stretch = 'stretch',
 }
 export type LayerFormat = LayerFormatValue.fill | LayerFormatValue.fit | LayerFormatValue.stretch
-
-export enum WaveformLayerStyleValue {
-  line = 'line',
-  wave = 'wave',
-}
-export type WaveformLayerStyle = WaveformLayerStyleValue.wave | WaveformLayerStyleValue.line
 
 export type LayerBase = {
   [LayerAttribute.start]?: number
@@ -124,10 +120,15 @@ export type LayerLottie = {
   [LayerAttribute.data]?: LottieAnimationData
 }
 
-export enum WaveformStyle {
-  bars = 'bars',
-  line = 'line',
+const bars = 'bars'
+const line = 'line'
+
+export const WaveformStyleValue: Record<string, WaveformStyle> = {
+  bars,
+  line,
 }
+export type WaveformStyle = typeof bars | typeof line
+
 export type LayerWaveform = {
   [LayerAttribute.style]?: WaveformStyle
 }

--- a/src/utils/video/compositions/index.ts
+++ b/src/utils/video/compositions/index.ts
@@ -28,6 +28,7 @@ import {
   validateLayerText,
   validateLayerTrim,
   validateLayerVisualMedia,
+  validateLayerWaveform,
 } from 'utils/video/layers'
 
 export const formDataKey = (file: CompositionFile, id: string): string => `${urlOrFile(file)}${id}`
@@ -160,7 +161,11 @@ export const validateAddFilter = (options: FilterLayer): void =>
   validateLayerMethod([validateLayerBase, validateLayerFilter], CompositionMethod.addFilter, options)
 
 export const validateAddWaveform = (options: WaveformLayer): void => {
-  validateLayerMethod([validateLayerBase, validateLayerVisualMedia], CompositionMethod.addWaveform, options)
+  validateLayerMethod(
+    [validateLayerBase, validateLayerVisualMedia, validateLayerWaveform],
+    CompositionMethod.addWaveform,
+    options
+  )
 
   const error = validateValueIsOfType(
     CompositionMethod.addWaveform,

--- a/src/utils/video/layers/index.ts
+++ b/src/utils/video/layers/index.ts
@@ -11,13 +11,46 @@ import {
   LayerTrim,
   LayerVerticalAlignmentValue,
   LayerVisualMedia,
+  LayerWaveform,
   PrimitiveType,
+  WaveformStyleValue,
 } from 'constant'
 import { ValidationErrorText } from 'strings'
 import { validateValueIsOfType } from 'utils/validation'
 import { validateFilter } from 'utils/video/filters'
 
 const filterUndefined = (maybeUndefined: unknown) => maybeUndefined !== undefined
+
+export const validateLayerAlignment = (
+  callerName: string,
+  { horizontalAlignment, verticalAlignment }: LayerAlignment
+): string[] => {
+  const errors: string[] = []
+  const acceptedVerticalValues = Object.values(LayerVerticalAlignmentValue)
+
+  errors.push(validateHorizontalAlignment(callerName, LayerAttribute.horizontalAlignment, horizontalAlignment))
+
+  if (verticalAlignment && !acceptedVerticalValues.includes(verticalAlignment)) {
+    errors.push(
+      ValidationErrorText.MUST_BE_TYPE(
+        callerName,
+        LayerAttribute.verticalAlignment,
+        verticalAlignment,
+        acceptedVerticalValues.join(', ')
+      )
+    )
+  }
+
+  return errors.filter(filterUndefined)
+}
+
+export const validateLayerAudio = (callerName: string, options: AudioLayer): string[] => {
+  const errors: string[] = []
+
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.volume, options.volume, PrimitiveType.number))
+
+  return errors.filter(filterUndefined)
+}
 
 export const validateLayerBase = (callerName: string, { length, start }: LayerBase): string[] => {
   const errors: string[] = []
@@ -28,6 +61,33 @@ export const validateLayerBase = (callerName: string, { length, start }: LayerBa
   return errors.filter(filterUndefined)
 }
 
+export const validateLayerFilter = (callerName: string, { filter }: FilterLayer): string[] => {
+  const errors: string[] = []
+
+  validateFilter(callerName, LayerAttribute.filter, filter).forEach((error) => errors.push(error))
+
+  return errors.filter(filterUndefined)
+}
+
+export const validateHorizontalAlignment = (
+  callerName: string,
+  layerAttribute: string,
+  horizontalAlignment: LayerHorizontalAlignment
+): string | undefined => {
+  const acceptedHorizontalValues = Object.values(LayerHorizontalAlignmentValue)
+
+  if (horizontalAlignment && !acceptedHorizontalValues.includes(horizontalAlignment)) {
+    return ValidationErrorText.MUST_BE_TYPE(
+      callerName,
+      layerAttribute,
+      horizontalAlignment,
+      acceptedHorizontalValues.join(', ')
+    )
+  }
+
+  return undefined
+}
+
 export const validateLayerLottie = (callerName: string, { data }: LayerLottie): string[] => {
   const errors: string[] = []
 
@@ -36,10 +96,19 @@ export const validateLayerLottie = (callerName: string, { data }: LayerLottie): 
   return errors.filter(filterUndefined)
 }
 
-export const validateLayerFilter = (callerName: string, { filter }: FilterLayer): string[] => {
+export const validateLayerText = (
+  callerName: string,
+  { fontFamily, fontSize, maxFontSize, maxHeight, maxWidth, text, textAlignment }: LayerText
+): string[] => {
   const errors: string[] = []
 
-  validateFilter(callerName, LayerAttribute.filter, filter).forEach((error) => errors.push(error))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.fontFamily, fontFamily, PrimitiveType.string))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.fontSize, fontSize, PrimitiveType.number))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxFontSize, maxFontSize, PrimitiveType.number))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxHeight, maxHeight, PrimitiveType.number))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxWidth, maxWidth, PrimitiveType.number))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.text, text, PrimitiveType.string))
+  errors.push(validateHorizontalAlignment(callerName, LayerAttribute.textAlignment, textAlignment))
 
   return errors.filter(filterUndefined)
 }
@@ -82,69 +151,18 @@ export const validateLayerVisualMedia = (
   return errors.filter(filterUndefined)
 }
 
-export const validateLayerAudio = (callerName: string, options: AudioLayer): string[] => {
+export const validateLayerWaveform = (callerName: string, { style }: LayerWaveform): string[] => {
   const errors: string[] = []
 
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.volume, options.volume, PrimitiveType.number))
+  errors.push(validateValueIsOfType(callerName, LayerAttribute.style, style, PrimitiveType.string))
 
-  return errors.filter(filterUndefined)
-}
+  const acceptedWaveformStyles = Object.values(WaveformStyleValue)
 
-export const validateHorizontalAlignment = (
-  callerName: string,
-  layerAttribute: string,
-  horizontalAlignment: LayerHorizontalAlignment
-): string | undefined => {
-  const acceptedHorizontalValues = Object.values(LayerHorizontalAlignmentValue)
-
-  if (horizontalAlignment && !acceptedHorizontalValues.includes(horizontalAlignment)) {
-    return ValidationErrorText.MUST_BE_TYPE(
-      callerName,
-      layerAttribute,
-      horizontalAlignment,
-      acceptedHorizontalValues.join(', ')
-    )
-  }
-
-  return undefined
-}
-
-export const validateLayerAlignment = (
-  callerName: string,
-  { horizontalAlignment, verticalAlignment }: LayerAlignment
-): string[] => {
-  const errors: string[] = []
-  const acceptedVerticalValues = Object.values(LayerVerticalAlignmentValue)
-
-  errors.push(validateHorizontalAlignment(callerName, LayerAttribute.horizontalAlignment, horizontalAlignment))
-
-  if (verticalAlignment && !acceptedVerticalValues.includes(verticalAlignment)) {
+  if (style && !acceptedWaveformStyles.includes(style)) {
     errors.push(
-      ValidationErrorText.MUST_BE_TYPE(
-        callerName,
-        LayerAttribute.verticalAlignment,
-        verticalAlignment,
-        acceptedVerticalValues.join(', ')
-      )
+      ValidationErrorText.MUST_BE_TYPE(callerName, LayerAttribute.style, style, acceptedWaveformStyles.join(', '))
     )
   }
-
-  return errors.filter(filterUndefined)
-}
-
-export const validateLayerText = (
-  callerName: string,
-  { fontFamily, fontSize, maxFontSize, maxHeight, maxWidth, text, textAlignment }: LayerText
-): string[] => {
-  const errors: string[] = []
-
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.fontFamily, fontFamily, PrimitiveType.string))
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.fontSize, fontSize, PrimitiveType.number))
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxFontSize, maxFontSize, PrimitiveType.number))
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxHeight, maxHeight, PrimitiveType.number))
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.maxWidth, maxWidth, PrimitiveType.number))
-  errors.push(validateValueIsOfType(callerName, LayerAttribute.text, text, PrimitiveType.string))
-  errors.push(validateHorizontalAlignment(callerName, LayerAttribute.textAlignment, textAlignment))
 
   return errors.filter(filterUndefined)
 }


### PR DESCRIPTION
In testing out the typescript example repo, I realized that using enums for values that users can pass in manually at the client means that the user would have to import our enums and use them the way we do internally. Instead, I set the individual values as constants and set the accepted values as string literals via `typeof center` etc...

I also alphabetized the validation utils folder when adding the `validateLayerWaveform` funciton