### PR TITLE
fix: exit node process on validation error

### DIFF
--- a/src/utils/validation/index.ts
+++ b/src/utils/validation/index.ts
@@ -57,6 +57,6 @@ export const withValidation = <T>(validate: () => void, callback?: () => T | und
   } catch ({ name, stack }) {
     logError(stack)
 
-    return undefined
+    process.exit(1)
   }
 }


### PR DESCRIPTION
I realized that by catching/printing these errors I was allowing the rest of the process to continue regardless. I tossed in a `process.exit(1)` to make sure we halt after printing the stack trace.