### PR TITLE
feat: addWaveform optionally takes a file instead of depending on final audio

### DIFF
--- a/src/features/videos/composition/composition.test.ts
+++ b/src/features/videos/composition/composition.test.ts
@@ -380,11 +380,13 @@ describe('Composition', () => {
       composition.addImage(filenames.image, imageOptions)
       composition.addText(textOptions)
       composition.addVideo(filenames.video, videoOptions)
-      composition.addWaveform(waveformOptions)
+      composition.addWaveform(waveformOptions, filenames.audio)
     })
 
     it('calls the `append` method on the private `formData` attribute with the correct arguments', async () => {
       await composition.encode()
+
+      expect(formDataMock.append).toHaveBeenCalledTimes(5)
 
       expect(formDataMock.append).toHaveBeenCalledWith(
         CompositionUtilsModule.formDataKey(filenames.audio, uuidMock),
@@ -398,6 +400,11 @@ describe('Composition', () => {
         CompositionUtilsModule.formDataKey(filenames.video, uuidMock),
         filenames.video
       )
+      expect(formDataMock.append).toHaveBeenCalledWith(
+        CompositionUtilsModule.formDataKey(filenames.audio, uuidMock),
+        filenames.audio
+      )
+
       expect(formDataMock.append).toHaveBeenCalledWith(
         'config',
         JSON.stringify({

--- a/src/features/videos/composition/index.ts
+++ b/src/features/videos/composition/index.ts
@@ -193,7 +193,7 @@ export class Composition implements CompositionInterface {
     )
   }
 
-  public [CompositionMethod.addWaveform](options: WaveformLayer = {}): VisualMedia | undefined {
+  public [CompositionMethod.addWaveform](options: WaveformLayer = {}, file?: CompositionFile): VisualMedia | undefined {
     return withValidation<VisualMedia>(
       () => {
         validatePresenceOf(options, CompositionErrorText.optionsRequired)
@@ -201,6 +201,10 @@ export class Composition implements CompositionInterface {
       },
       () => {
         const { id } = this._addLayer({ type: LayerType.waveform, ...options })
+
+        if (file) {
+          this._files.push({ file, id })
+        }
 
         return new VisualMedia({ composition: this, id })
       }


### PR DESCRIPTION
* calling `addWaveform` without a file will use the final audio as the audio input source