### PR TITLE
fix: use new filter types and FontWeight type

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
-    "@editframe/shared-types": "^1.3.0",
+    "@editframe/shared-types": "^1.3.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@semantic-release/changelog": "^6.0.1",

--- a/src/constant/video/filters.ts
+++ b/src/constant/video/filters.ts
@@ -3,6 +3,7 @@ import {
   FilterContrast,
   FilterFadeIn,
   FilterName,
+  FilterNames,
   FilterOptionKey,
   FilterOptions,
   FilterSaturation,
@@ -40,7 +41,7 @@ export enum FilterAttribute {
 }
 
 export type Filter = {
-  [FilterAttribute.filterName]: FilterName
+  [FilterAttribute.filterName]: FilterNames
   [FilterAttribute.options]?: FilterBrightness | FilterContrast | FilterFadeIn | FilterSaturation
 }
 

--- a/src/constant/video/layers.ts
+++ b/src/constant/video/layers.ts
@@ -1,4 +1,5 @@
 import {
+  FontWeight,
   LayerAttribute,
   LayerHorizontalAlignment,
   LayerHorizontalAlignmentValue,
@@ -11,6 +12,7 @@ import {
 import { Filter } from 'constant/video/filters'
 import { LottieAnimationData } from 'constant/video/lottie'
 
+export type { FontWeight as FontWeight }
 export { LayerAttribute as LayerAttribute }
 export type { LayerHorizontalAlignment as LayerHorizontalAlignment }
 export { LayerHorizontalAlignmentValue as LayerHorizontalAlignmentValue }
@@ -70,7 +72,7 @@ export type LayerVisualMedia = Size & {
 export type LayerText = {
   [LayerAttribute.fontFamily]?: string
   [LayerAttribute.fontSize]?: number
-  [LayerAttribute.fontWeight]?: number | string
+  [LayerAttribute.fontWeight]?: FontWeight
   [LayerAttribute.lineHeight]?: number
   [LayerAttribute.maxFontSize]?: number
   [LayerAttribute.maxHeight]?: number

--- a/src/features/videos/filter/index.ts
+++ b/src/features/videos/filter/index.ts
@@ -1,4 +1,4 @@
-import { CompositionInterface, FilterMethod, FilterOptions, LayerAttribute } from 'constant'
+import { CompositionInterface, FilterMethod, Filter as FilterType, LayerAttribute } from 'constant'
 import { Layer } from 'features/videos/layer'
 import { validateFilter, withValidation } from 'utils'
 
@@ -7,13 +7,7 @@ export class Filter extends Layer {
     super({ composition, id })
   }
 
-  public [FilterMethod.setFilter]<FilterName extends keyof FilterOptions>({
-    filterName,
-    options,
-  }: {
-    filterName: FilterName
-    options: FilterOptions[FilterName]
-  }): this | void {
+  public [FilterMethod.setFilter]({ filterName, options }: FilterType): this | void {
     return withValidation<this>(
       () => validateFilter(FilterMethod.setFilter, LayerAttribute.filter, { filterName, options }, true),
       () => this._updateAttribute(LayerAttribute.filter, { filterName, options })

--- a/src/features/videos/text/index.ts
+++ b/src/features/videos/text/index.ts
@@ -1,4 +1,11 @@
-import { CompositionInterface, LayerAttribute, LayerHorizontalAlignment, PrimitiveType, TextMethod } from 'constant'
+import {
+  CompositionInterface,
+  FontWeight,
+  LayerAttribute,
+  LayerHorizontalAlignment,
+  PrimitiveType,
+  TextMethod,
+} from 'constant'
 import { VisualMedia } from 'features/videos/visualMedia'
 import { CompositionErrorText } from 'strings'
 import {
@@ -36,7 +43,7 @@ export class Text extends VisualMedia {
     )
   }
 
-  public [TextMethod.setFontWeight](fontWeight?: number | string): this | void {
+  public [TextMethod.setFontWeight](fontWeight?: FontWeight): this | void {
     return withValidation<this>(
       () =>
         validateValueIsOfTypes(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,10 +1110,10 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@editframe/shared-types@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@editframe/shared-types/-/shared-types-1.3.0.tgz#56c859dcf7e4067cc9b0fa2aac58d6159868fde0"
-  integrity sha512-gzQ3nRHyt7JetEvdvQm4e+iLF4Q0VyiMmcsNQ53tsUCkNeNikzKg8q3/fOJtp3k1ZmwB2uaT5p1Sy0YhtLfBGw==
+"@editframe/shared-types@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@editframe/shared-types/-/shared-types-1.3.1.tgz#b85072deec8420f4cbb7a9a1b938b6ee7572ce05"
+  integrity sha512-7JIwVM8Pa/bVo5X9wa3nv55y/muyEK91AQOV5dhr8UQitbHxeXv4mJByfDBI90ppP/QIlFi7bSQQxYwyEHmEKw==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
* use consts instead of enums so ts users don't have to supply actual enum value
* use `FontWeight` type