### PR TITLE
fix: deepClone layers on setting new layer. deepMerge options when adding layer

### DIFF
--- a/src/features/videos/composition/composition.test.ts
+++ b/src/features/videos/composition/composition.test.ts
@@ -407,6 +407,9 @@ describe('Composition', () => {
       it('adds an `html` layer with the correct attributes', () => {
         expect(composition.layers[0]).toEqual(
           deepMerge(layer, {
+            html: {
+              page: sanitizedHtmlMock,
+            },
             id: uuidMock,
             type: LayerType.html,
           })

--- a/src/features/videos/composition/index.ts
+++ b/src/features/videos/composition/index.ts
@@ -76,6 +76,7 @@ import {
   createReadStream,
   createTemporaryDirectory,
   deepClone,
+  deepMerge,
   formDataKey,
   getExtension,
   isAudioExtension,
@@ -265,7 +266,7 @@ export class Composition implements CompositionInterface {
         const {
           html: { page },
         } = htmlLayer
-        const transformedLayer: HtmlLayer = { ...htmlLayer }
+        const transformedLayer: HtmlLayer = deepClone(htmlLayer)
 
         if (page) {
           transformedLayer.html.page = await sanitizeHtml(page)
@@ -528,7 +529,7 @@ export class Composition implements CompositionInterface {
   }
 
   private _addLayer(options: TypedLayer): IdentifiedLayer {
-    const newLayer: IdentifiedLayer = { id: uuid(), ...options }
+    const newLayer: IdentifiedLayer = deepMerge({ id: uuid() }, options)
 
     this._layers.push(newLayer)
 
@@ -570,7 +571,7 @@ export class Composition implements CompositionInterface {
   }
 
   private [CompositionMethod.setLayer](id: string, newLayer: IdentifiedLayer): void {
-    const newLayers = [...this.layers]
+    const newLayers = deepClone(this.layers)
     const layerIndex = newLayers.findIndex((layer) => layer.id === id)
 
     newLayers[layerIndex] = newLayer


### PR DESCRIPTION
* shallow merging and cloning in these two places were causing child references to get updated mistakenly