### PR TITLE
fix: validate duration on encode instead of composition instantiation

### DIFF
--- a/src/constant/video/compositions.ts
+++ b/src/constant/video/compositions.ts
@@ -88,7 +88,7 @@ export type VideoOptions = {
 export type CompositionOptions = {
   [CompositionKey.backgroundColor]?: string
   [CompositionKey.dimensions]: Dimensions
-  [CompositionKey.duration]: number
+  [CompositionKey.duration]?: number
   [CompositionKey.metadata]?: Metadata
 }
 

--- a/src/features/videos/composition/composition.test.ts
+++ b/src/features/videos/composition/composition.test.ts
@@ -774,6 +774,23 @@ describe('Composition', () => {
   })
 
   describe('encode', () => {
+    describe('when no `duration` exists on the `composition`', () => {
+      it('logs an error to the console', async () => {
+        composition = new Composition({
+          api: apiMock,
+          formData: formDataMock,
+          options: { ...options, duration: 0 },
+          temporaryDirectory,
+        })
+
+        await composition.encode()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          CompositionErrorText.errorEncoding(CompositionErrorText.durationRequired)
+        )
+      })
+    })
+
     describe('when the encode response is malformed', () => {
       beforeEach(() => {
         postMock.mockResolvedValue({})

--- a/src/features/videos/composition/index.ts
+++ b/src/features/videos/composition/index.ts
@@ -500,9 +500,13 @@ export class Composition implements CompositionInterface {
   }
 
   public async [CompositionMethod.encode](): Promise<EncodeResponse> {
-    this._generateConfig()
-
     try {
+      if (!this.duration) {
+        throw new Error(CompositionErrorText.durationRequired)
+      }
+
+      this._generateConfig()
+
       const data = await this._api.post({ data: this._formData, isForm: true, url: Routes.videos.create })
 
       removeDirectory(this._temporaryDirectory)

--- a/src/strings/video/compositions.ts
+++ b/src/strings/video/compositions.ts
@@ -8,9 +8,11 @@ export const CompositionErrorText = {
   dimensionsRequired: `\\${colors.white('dimensions')}\\ must be provided unless a \\${colors.white(
     'videoFile'
   )}\\ is provided`,
-  durationRequired: `\\${colors.white('duration')}\\ must be provided unless a \\${colors.white(
+  durationRequired: `\\${colors.white(
+    'duration'
+  )}\\ must be provided unless composition is instantiated from a \\${colors.white(
     'videoFile'
-  )}\\ is provided`,
+  )}\\ or calculated automatically via a call to \\${colors.white('addSequence')}\\`,
   errorEncoding: (error: string): string => `Error encoding video: ${error}`,
   filterRequired: `\\${colors.white('filter')}\\ must be provided`,
   htmlPageOrUrlRequired: `Either \\${colors.white('page')}\\ or \\${colors.white('url')}\\ must be provided`,

--- a/src/utils/validation/composition/composition.test.ts
+++ b/src/utils/validation/composition/composition.test.ts
@@ -2,14 +2,13 @@ import { PassThrough } from 'stream'
 
 import { ApiVideoMethod, CompositionKey, DimensionsKey, PrimitiveType } from 'constant'
 import { mockCompositionOptions } from 'mocks'
-import { CompositionErrorText, MediaErrorText, ValidationErrorText } from 'strings'
+import { MediaErrorText, ValidationErrorText } from 'strings'
 import * as ValidationUtilsModule from 'utils/validation'
 
 import { validateCompositionFile, validateCompositionOptions } from './'
 
 describe('validations', () => {
   const callerName = 'caller-name'
-  let validatePresenceOfSpy: jest.SpyInstance
   let validateValueIsOfTypeSpy: jest.SpyInstance
 
   afterEach(() => {
@@ -17,7 +16,6 @@ describe('validations', () => {
   })
 
   beforeEach(() => {
-    validatePresenceOfSpy = jest.spyOn(ValidationUtilsModule, 'validatePresenceOf')
     validateValueIsOfTypeSpy = jest.spyOn(ValidationUtilsModule, 'validateValueIsOfType')
   })
 
@@ -53,13 +51,7 @@ describe('validations', () => {
 
   describe('validateCompositionOptions', () => {
     const compositionOptions = mockCompositionOptions()
-    const { backgroundColor, dimensions, duration } = compositionOptions
-
-    it('calls the `validatePresenceOf` function with the correct arguments', () => {
-      validateCompositionOptions(compositionOptions)
-
-      expect(validatePresenceOfSpy).toHaveBeenCalledWith(duration, CompositionErrorText.durationRequired)
-    })
+    const { backgroundColor, dimensions } = compositionOptions
 
     it('calls the `validateValueIsOfType` function with the correct arguments', () => {
       validateCompositionOptions(compositionOptions)

--- a/src/utils/validation/composition/index.ts
+++ b/src/utils/validation/composition/index.ts
@@ -21,10 +21,9 @@ export const validateCompositionFile = (callerName: string, file: CompositionFil
   }
 }
 
-export const validateCompositionOptions = ({ backgroundColor, dimensions, duration }: CompositionOptions): void => {
+export const validateCompositionOptions = ({ backgroundColor, dimensions }: CompositionOptions): void => {
   const errors: string[] = []
 
-  validatePresenceOf(duration, CompositionErrorText.durationRequired)
   validatePresenceOf(dimensions, CompositionErrorText.dimensionsRequired)
 
   errors.push(


### PR DESCRIPTION
* move `duration` validation from `composition` instantiation to `encode`