### PR TITLE
try to get semantic release to set version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,5 @@
     "test:watch": "jest --watch"
   },
   "types": "dist/index.d.ts",
-  "version": "0.2.4"
+  "version": ""
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,17 +1,11 @@
 module.exports = {
-  branches: 'main',
+  branches: ['main'],
   plugins: [
-    '@semantic-release/changelog',
     '@semantic-release/commit-analyzer',
-    [
-      '@semantic-release/git',
-      {
-        assets: ['README.md', 'dist/**'],
-        message: 'chore(release): set `package.json` to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-      },
-    ],
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/changelog',
     '@semantic-release/github',
     '@semantic-release/npm',
-    '@semantic-release/release-notes-generator',
+    '@semantic-release/git',
   ],
 }


### PR DESCRIPTION
* use default `@semantic-release` `git` plugin  config
* set `version` in package.json to `''` in the hopes `semantic-release` will write to it on next release