### PR TITLE
fix: update expected type of `perPage` in Video pagination metadata

### DIFF
--- a/src/constant/pagination/index.ts
+++ b/src/constant/pagination/index.ts
@@ -49,7 +49,7 @@ export interface PaginationMeta {
   [PaginationMetaKey.lastPage]: number
   [PaginationMetaKey.links]: PaginationMetaLink[]
   [PaginationMetaKey.path]: string
-  [PaginationMetaKey.perPage]: string
+  [PaginationMetaKey.perPage]: number
   [PaginationMetaKey.to]: number
   [PaginationMetaKey.total]: number
 }

--- a/src/constant/videos/index.ts
+++ b/src/constant/videos/index.ts
@@ -1,4 +1,4 @@
-import { Hashided, Timestamped } from 'constant/common'
+import { Hashided } from 'constant/common'
 
 export enum ApiVideoKey {
   downloadUrl = 'downloadUrl',
@@ -12,17 +12,16 @@ export enum ApiVideoKey {
   timestamp = 'timestamp',
 }
 
-export type ApiVideo = Hashided &
-  Timestamped & {
-    [ApiVideoKey.downloadUrl]?: string
-    [ApiVideoKey.duration]?: number
-    [ApiVideoKey.isFailed]: boolean
-    [ApiVideoKey.isReady]: boolean
-    [ApiVideoKey.metadata]: Record<string, unknown>
-    [ApiVideoKey.streamUrl]?: string
-    [ApiVideoKey.thumbnailUrl]?: string
-    [ApiVideoKey.timestamp]: number
-  }
+export type ApiVideo = Hashided & {
+  [ApiVideoKey.downloadUrl]?: string
+  [ApiVideoKey.duration]?: number
+  [ApiVideoKey.isFailed]: boolean
+  [ApiVideoKey.isReady]: boolean
+  [ApiVideoKey.metadata]: Record<string, any>
+  [ApiVideoKey.streamUrl]?: string
+  [ApiVideoKey.thumbnailUrl]?: string
+  [ApiVideoKey.timestamp]: number
+}
 
 export enum ApiVideoMethod {
   all = 'all',

--- a/src/mocks/pagination.ts
+++ b/src/mocks/pagination.ts
@@ -17,7 +17,7 @@ export const mockPagination = <T>(data: T[]): Paginated<T> => ({
       },
     ],
     path: 'path',
-    perPage: '10',
+    perPage: 10,
     to: 20,
     total: 100,
   },

--- a/src/mocks/videos.ts
+++ b/src/mocks/videos.ts
@@ -1,20 +1,7 @@
 import { ApiVideo } from 'constant'
 
 export const mockApiVideo = (
-  {
-    createdAt,
-    downloadUrl,
-    duration,
-    id,
-    isFailed,
-    isReady,
-    metadata,
-    streamUrl,
-    thumbnailUrl,
-    timestamp,
-    updatedAt,
-  }: ApiVideo = {
-    createdAt: 'createdAt',
+  { downloadUrl, duration, id, isFailed, isReady, metadata, streamUrl, thumbnailUrl, timestamp }: ApiVideo = {
     downloadUrl: 'download-url',
     duration: 100,
     id: 'id',
@@ -24,10 +11,8 @@ export const mockApiVideo = (
     streamUrl: 'stream-url',
     thumbnailUrl: 'thumbnail-url',
     timestamp: 50,
-    updatedAt: 'updated-at',
   }
 ): ApiVideo => ({
-  createdAt,
   downloadUrl,
   duration,
   id,
@@ -37,5 +22,4 @@ export const mockApiVideo = (
   streamUrl,
   thumbnailUrl,
   timestamp,
-  updatedAt,
 })

--- a/src/utils/validation/pagination/index.ts
+++ b/src/utils/validation/pagination/index.ts
@@ -35,7 +35,7 @@ const isPaginationMeta = (paginationMeta: any): paginationMeta is PaginationMeta
   PaginationMetaKey.path in paginationMeta &&
   assertType(paginationMeta.path, PrimitiveType.string) &&
   PaginationMetaKey.perPage in paginationMeta &&
-  assertType(paginationMeta.perPage, PrimitiveType.string) &&
+  assertType(paginationMeta.perPage, PrimitiveType.number) &&
   PaginationMetaKey.to in paginationMeta &&
   assertType(paginationMeta.to, [PrimitiveType.number, PrimitiveType.null]) &&
   PaginationMetaKey.total in paginationMeta &&


### PR DESCRIPTION
* update `perPage` attribute in `paginationMetadata` to match backend change from a `string` to `number`,
* removes `timestamp` keys as they are not returned by the backend