### PR TITLE
fix: dont set default size of image layer to the composition dimensions

### DIFF
--- a/src/features/videos/layers/image/image.test.ts
+++ b/src/features/videos/layers/image/image.test.ts
@@ -21,7 +21,7 @@ describe('Image', () => {
       options: { dimensions: { height: 1080, width: 1920 }, duration: 10 },
     })
     image = await composition.addImage('./package.json')
-    layerConfigDefaults = makeDefaultImageLayerConfig(composition.dimensions)
+    layerConfigDefaults = makeDefaultImageLayerConfig()
 
     jest.clearAllMocks()
   })

--- a/src/utils/defaults/image.ts
+++ b/src/utils/defaults/image.ts
@@ -1,5 +1,4 @@
 import {
-  Dimensions,
   ImageLayer,
   ImageLayerConfig,
   defaultBackground,
@@ -7,21 +6,27 @@ import {
   defaultTimeline,
   defaultTrim,
 } from 'constant'
-import { makeDefaultSize } from 'utils/defaults/size'
 import { deepMerge } from 'utils/objects'
 
-export const makeDefaultImageLayerConfig = (dimensions: Dimensions): ImageLayerConfig => {
+export const makeDefaultImageLayerConfig = (): ImageLayerConfig => {
   const defaults: ImageLayerConfig = {}
 
-  deepMerge(defaults, defaultBackground, defaultPosition, makeDefaultSize(dimensions), defaultTimeline, defaultTrim)
+  deepMerge(
+    defaults,
+    defaultBackground,
+    defaultPosition,
+    { size: { height: null, width: null } },
+    defaultTimeline,
+    defaultTrim
+  )
 
   return defaults
 }
 
-export const makeDefaultImageLayer = (dimensions: Dimensions): ImageLayer => {
+export const makeDefaultImageLayer = (): ImageLayer => {
   const defaults: ImageLayer = {}
 
-  deepMerge(defaults, makeDefaultImageLayerConfig(dimensions))
+  deepMerge(defaults, makeDefaultImageLayerConfig())
 
   return defaults
 }

--- a/src/utils/video/compositions/compositions.test.ts
+++ b/src/utils/video/compositions/compositions.test.ts
@@ -84,7 +84,7 @@ describe('setLayerDefaults', () => {
   })
 
   describe('image', () => {
-    const defaultImageLayer = makeDefaultImageLayer(dimensions)
+    const defaultImageLayer = makeDefaultImageLayer()
 
     it('sets the correct layer defaults when no options or config are provided', () => {
       expect(setLayerDefaults(dimensions, LayerType.image, {}, {})).toEqual(defaultImageLayer)

--- a/src/utils/video/compositions/index.ts
+++ b/src/utils/video/compositions/index.ts
@@ -59,7 +59,7 @@ export const setLayerDefaults = <Layer>(
     [LayerType.audio]: makeDefaultAudioLayer(),
     [LayerType.filter]: defaultFilterLayer,
     [LayerType.html]: makeDefaultHtmlLayer(defaultDimensions),
-    [LayerType.image]: makeDefaultImageLayer(defaultDimensions),
+    [LayerType.image]: makeDefaultImageLayer(),
     [LayerType.lottie]: makeDefaultLottieLayer(defaultDimensions),
     [LayerType.sequence]: makeDefaultSequenceLayer(),
     [LayerType.subtitles]: makeDefaultSubtitlesLayer(),


### PR DESCRIPTION
* this was causing images to get stretched 