### PR TITLE
fix: dont default lottie or video size to composition dimensions

### DIFF
--- a/src/constant/video/mixins/size.ts
+++ b/src/constant/video/mixins/size.ts
@@ -1,6 +1,15 @@
+import { Size } from 'constant/shared'
+
 export enum SizeMethod {
   setDimensions = 'setDimensions',
   setFormat = 'setFormat',
   setHeight = 'setHeight',
   setWidth = 'setWidth',
+}
+
+export const defaultSize: Size = {
+  size: {
+    height: null,
+    width: null,
+  },
 }

--- a/src/features/videos/layers/lottie/lottie.test.ts
+++ b/src/features/videos/layers/lottie/lottie.test.ts
@@ -38,7 +38,7 @@ describe('Lottie', () => {
       formData: { append: jest.fn() },
       options: { dimensions: { height: 1080, width: 1920 }, duration: 10 },
     })
-    defaultLottieLayerConfig = makeDefaultLottieLayerConfig(composition.dimensions)
+    defaultLottieLayerConfig = makeDefaultLottieLayerConfig()
     validatePresenceOfSpy = jest.spyOn(ValidationUtilsModule, 'validatePresenceOf')
     validateValueIsOfTypeSpy = jest.spyOn(ValidationUtilsModule, 'validateValueIsOfType')
     lottie = composition.addLottie(lottieOptions)

--- a/src/features/videos/layers/video/video.test.ts
+++ b/src/features/videos/layers/video/video.test.ts
@@ -21,7 +21,7 @@ describe('Video', () => {
       options: { dimensions: { height: 1080, width: 1920 }, duration: 10 },
     })
     video = await composition.addVideo('./package.json')
-    layerConfigDefaults = makeDefaultVideoLayerConfig(composition.dimensions)
+    layerConfigDefaults = makeDefaultVideoLayerConfig()
 
     jest.clearAllMocks()
   })

--- a/src/utils/defaults/image.ts
+++ b/src/utils/defaults/image.ts
@@ -3,6 +3,7 @@ import {
   ImageLayerConfig,
   defaultBackground,
   defaultPosition,
+  defaultSize,
   defaultTimeline,
   defaultTrim,
 } from 'constant'
@@ -11,14 +12,7 @@ import { deepMerge } from 'utils/objects'
 export const makeDefaultImageLayerConfig = (): ImageLayerConfig => {
   const defaults: ImageLayerConfig = {}
 
-  deepMerge(
-    defaults,
-    defaultBackground,
-    defaultPosition,
-    { size: { height: null, width: null } },
-    defaultTimeline,
-    defaultTrim
-  )
+  deepMerge(defaults, defaultBackground, defaultPosition, defaultSize, defaultTimeline, defaultTrim)
 
   return defaults
 }

--- a/src/utils/defaults/lottie.ts
+++ b/src/utils/defaults/lottie.ts
@@ -1,28 +1,27 @@
 import {
-  Dimensions,
   LottieLayer,
   LottieLayerConfig,
   LottieOptions,
   defaultLottieOptions,
   defaultPosition,
+  defaultSize,
   defaultTimeline,
   defaultTrim,
 } from 'constant'
-import { makeDefaultSize } from 'utils/defaults/size'
 import { deepMerge } from 'utils/objects'
 
-export const makeDefaultLottieLayerConfig = (dimensions: Dimensions): LottieLayerConfig => {
+export const makeDefaultLottieLayerConfig = (): LottieLayerConfig => {
   const defaults: LottieLayerConfig = {}
 
-  deepMerge(defaults, defaultPosition, makeDefaultSize(dimensions), defaultTimeline, defaultTrim)
+  deepMerge(defaults, defaultPosition, defaultSize, defaultTimeline, defaultTrim)
 
   return defaults
 }
 
-export const makeDefaultLottieLayer = (dimensions: Dimensions): LottieLayer => {
+export const makeDefaultLottieLayer = (): LottieLayer => {
   const defaults: LottieLayer = { lottie: {} as LottieOptions }
 
-  deepMerge(defaults, { lottie: defaultLottieOptions }, makeDefaultLottieLayerConfig(dimensions))
+  deepMerge(defaults, { lottie: defaultLottieOptions }, makeDefaultLottieLayerConfig())
 
   return defaults
 }

--- a/src/utils/defaults/video.ts
+++ b/src/utils/defaults/video.ts
@@ -1,36 +1,27 @@
 import {
-  Dimensions,
   VideoLayer,
   VideoLayerConfig,
   defaultAudio,
   defaultBackground,
   defaultPosition,
+  defaultSize,
   defaultTimeline,
   defaultTrim,
 } from 'constant'
-import { makeDefaultSize } from 'utils/defaults/size'
 import { deepMerge } from 'utils/objects'
 
-export const makeDefaultVideoLayerConfig = (dimensions: Dimensions): VideoLayerConfig => {
+export const makeDefaultVideoLayerConfig = (): VideoLayerConfig => {
   const defaults = {}
 
-  deepMerge(
-    defaults,
-    defaultAudio,
-    defaultBackground,
-    defaultPosition,
-    makeDefaultSize(dimensions),
-    defaultTimeline,
-    defaultTrim
-  )
+  deepMerge(defaults, defaultAudio, defaultBackground, defaultPosition, defaultSize, defaultTimeline, defaultTrim)
 
   return defaults
 }
 
-export const makeDefaultVideoLayer = (dimensions: Dimensions): VideoLayer => {
+export const makeDefaultVideoLayer = (): VideoLayer => {
   const defaults: VideoLayer = {}
 
-  deepMerge(defaults, makeDefaultVideoLayerConfig(dimensions))
+  deepMerge(defaults, makeDefaultVideoLayerConfig())
 
   return defaults
 }

--- a/src/utils/video/compositions/compositions.test.ts
+++ b/src/utils/video/compositions/compositions.test.ts
@@ -100,7 +100,7 @@ describe('setLayerDefaults', () => {
   })
 
   describe('lottie', () => {
-    const defaultLottieLayer = makeDefaultLottieLayer(dimensions)
+    const defaultLottieLayer = makeDefaultLottieLayer()
 
     it('sets the correct layer defaults when no options or config are provided', () => {
       expect(setLayerDefaults(dimensions, LayerType.lottie, {}, {})).toEqual(defaultLottieLayer)
@@ -167,7 +167,7 @@ describe('setLayerDefaults', () => {
   })
 
   describe('video', () => {
-    const defaultVideoLayer = makeDefaultVideoLayer(dimensions)
+    const defaultVideoLayer = makeDefaultVideoLayer()
 
     it('sets the correct layer defaults when no options or config are provided', () => {
       expect(setLayerDefaults(dimensions, LayerType.video, {}, {})).toEqual(defaultVideoLayer)

--- a/src/utils/video/compositions/index.ts
+++ b/src/utils/video/compositions/index.ts
@@ -60,11 +60,11 @@ export const setLayerDefaults = <Layer>(
     [LayerType.filter]: defaultFilterLayer,
     [LayerType.html]: makeDefaultHtmlLayer(defaultDimensions),
     [LayerType.image]: makeDefaultImageLayer(),
-    [LayerType.lottie]: makeDefaultLottieLayer(defaultDimensions),
+    [LayerType.lottie]: makeDefaultLottieLayer(),
     [LayerType.sequence]: makeDefaultSequenceLayer(),
     [LayerType.subtitles]: makeDefaultSubtitlesLayer(),
     [LayerType.text]: makeDefaultTextLayer(defaultDimensions),
-    [LayerType.video]: makeDefaultVideoLayer(defaultDimensions),
+    [LayerType.video]: makeDefaultVideoLayer(),
     [LayerType.waveform]: makeDefaultWaveformLayer(defaultDimensions),
   }
 


### PR DESCRIPTION
* was testing out the sequence and realized that when using a different composition dimensions than the original video content, the video got stretched. so I removed the defaulting to composition from both lottie and video. It should only be being done for `html`, `waveform`, and `text` now, where there is no original input media that would be devoid of a resolution