### PR TITLE
rmDir → rm

### DIFF
--- a/src/utils/files/files.test.ts
+++ b/src/utils/files/files.test.ts
@@ -73,11 +73,11 @@ describe('getExtension', () => {
 describe('removeDirectory', () => {
   const directory = 'directory'
   let existsSyncSpy: jest.SpyInstance
-  let rmdirSyncSpy: jest.SpyInstance
+  let rmSyncSpy: jest.SpyInstance
 
   beforeEach(() => {
     existsSyncSpy = jest.spyOn(fs, 'existsSync')
-    rmdirSyncSpy = jest.spyOn(fs, 'rmdirSync').mockImplementation(() => 'path')
+    rmSyncSpy = jest.spyOn(fs, 'rmSync').mockImplementation(() => 'path')
   })
 
   it('does nothing when the provided directory does not exist', () => {
@@ -85,7 +85,7 @@ describe('removeDirectory', () => {
 
     removeDirectory(directory)
 
-    expect(rmdirSyncSpy).not.toHaveBeenCalled()
+    expect(rmSyncSpy).not.toHaveBeenCalled()
   })
 
   it('calls the `mkdirSync` function with the correct arguments when the provided directory does not exist', () => {
@@ -93,7 +93,7 @@ describe('removeDirectory', () => {
 
     removeDirectory(directory)
 
-    expect(rmdirSyncSpy).toHaveBeenCalledWith(directory, { recursive: true })
+    expect(rmSyncSpy).toHaveBeenCalledWith(directory, { recursive: true })
   })
 })
 

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -1,5 +1,5 @@
 import { fetch } from 'cross-fetch'
-import fs, { createWriteStream, existsSync, mkdirSync, rmdirSync, writeFileSync } from 'fs'
+import fs, { createWriteStream, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { parse, resolve } from 'path'
 import { Readable } from 'stream'
 
@@ -42,7 +42,7 @@ export const getExtension = (filepath: string): string => parse(filepath).ext
 
 export const removeDirectory = (directory: string): void => {
   if (fileExists(directory)) {
-    rmdirSync(directory, { recursive: true })
+    rmSync(directory, { recursive: true })
   }
 }
 


### PR DESCRIPTION
because we were getting the following deprecation warning :

> In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
