### PR TITLE
fix: dont supply default dimensions for addHtml

### DIFF
--- a/src/constant/video/layers/text.ts
+++ b/src/constant/video/layers/text.ts
@@ -1,5 +1,6 @@
 export enum TextMethod {
   setBackgroundColor = 'setBackgroundColor',
+  setBackgroundTransform = 'setBackgroundTransform',
   setBorder = 'setBorder',
   setBorderRadius = 'setBorderRadius',
   setColor = 'setColor',
@@ -13,4 +14,5 @@ export enum TextMethod {
   setTextAlign = 'setTextAlign',
   setTextDecoration = 'setTextDecoration',
   setTextPosition = 'setTextPosition',
+  setTextTransform = 'setTextTransform',
 }

--- a/src/features/videos/layers/html/html.test.ts
+++ b/src/features/videos/layers/html/html.test.ts
@@ -32,7 +32,7 @@ describe('Html', () => {
     validateValueIsOfTypeSpy = jest.spyOn(ValidationUtilsModule, 'validateValueIsOfType')
 
     html = await composition.addHtml({ page })
-    layerConfigDefaults = makeDefaultHtmlLayerConfig(composition.dimensions)
+    layerConfigDefaults = makeDefaultHtmlLayerConfig()
 
     jest.clearAllMocks()
   })

--- a/src/features/videos/layers/text/index.ts
+++ b/src/features/videos/layers/text/index.ts
@@ -41,8 +41,12 @@ export class Text extends Mixin(PositionMixin, SizeMixin, TimelineMixin, Transit
     return LayerType.text
   }
 
-  get backgroundColor(): string | undefined {
-    return this._getTextAttribute<string | undefined>(TextKey.backgroundColor)
+  get backgroundColor(): string {
+    return this._getTextAttribute<string>(TextKey.backgroundColor)
+  }
+
+  get backgroundTransform(): string {
+    return this._getTextAttribute<string>(TextKey.backgroundTransform)
   }
 
   get border(): string {
@@ -97,6 +101,10 @@ export class Text extends Mixin(PositionMixin, SizeMixin, TimelineMixin, Transit
     return this._getTextAttribute<TextPosition>(TextKey.textPosition)
   }
 
+  get textTransform(): string {
+    return this._getTextAttribute<string>(TextKey.textTransform)
+  }
+
   public [TextMethod.setBackgroundColor](backgroundColor: string): this {
     return withValidation<this>(
       () =>
@@ -108,6 +116,20 @@ export class Text extends Mixin(PositionMixin, SizeMixin, TimelineMixin, Transit
           true
         ),
       () => this._setTextAttribute(TextKey.backgroundColor, backgroundColor)
+    )
+  }
+
+  public [TextMethod.setBackgroundTransform](backgroundTransform: string): this {
+    return withValidation<this>(
+      () =>
+        validateValueIsOfType(
+          TextMethod.setBackgroundTransform,
+          TextKey.backgroundTransform,
+          backgroundTransform,
+          PrimitiveType.string,
+          true
+        ),
+      () => this._setTextAttribute(TextKey.backgroundTransform, backgroundTransform)
     )
   }
 
@@ -216,6 +238,20 @@ export class Text extends Mixin(PositionMixin, SizeMixin, TimelineMixin, Transit
     return withValidation<this>(
       () => validateTextPosition(TextMethod.setTextPosition, textPosition),
       () => this._setTextAttribute(TextKey.textPosition, textPosition)
+    )
+  }
+
+  public [TextMethod.setTextTransform](textTransform: string): this {
+    return withValidation<this>(
+      () =>
+        validateValueIsOfType(
+          TextMethod.setTextTransform,
+          TextKey.textTransform,
+          textTransform,
+          PrimitiveType.string,
+          true
+        ),
+      () => this._setTextAttribute(TextKey.textTransform, textTransform)
     )
   }
 

--- a/src/features/videos/layers/text/text.test.ts
+++ b/src/features/videos/layers/text/text.test.ts
@@ -117,6 +117,34 @@ describe('Text', () => {
     })
   })
 
+  describe('setBackgroundTransform', () => {
+    const backgroundTransform = 'backgroundTransform'
+
+    beforeEach(() => {
+      result = text.setBackgroundTransform(backgroundTransform)
+    })
+
+    it('calls the `validateValueIsOfType` function', () => {
+      expect(validateValueIsOfTypeSpy).toHaveBeenCalledWith(
+        TextMethod.setBackgroundTransform,
+        TextKey.backgroundTransform,
+        backgroundTransform,
+        PrimitiveType.string,
+        true
+      )
+    })
+
+    it('sets the `backgroundColor`', () => {
+      text.setBackgroundTransform(backgroundTransform)
+
+      expect(text.backgroundTransform).toEqual(backgroundTransform)
+    })
+
+    it('returns the `Text` instance', () => {
+      expect(result).toBeInstanceOf(Text)
+    })
+  })
+
   describe('setBorder', () => {
     const border = 'border'
 
@@ -434,6 +462,34 @@ describe('Text', () => {
 
     it('sets the `textPosition`', () => {
       expect(text.textPosition).toEqual(textPosition)
+    })
+
+    it('returns the `Text` instance', () => {
+      expect(result).toBeInstanceOf(Text)
+    })
+  })
+
+  describe('setTextTransform', () => {
+    const textTransform = 'textTransform'
+
+    beforeEach(() => {
+      result = text.setTextTransform(textTransform)
+    })
+
+    it('calls the `validateValueIsOfType` function', () => {
+      expect(validateValueIsOfTypeSpy).toHaveBeenCalledWith(
+        TextMethod.setTextTransform,
+        TextKey.textTransform,
+        textTransform,
+        PrimitiveType.string,
+        true
+      )
+    })
+
+    it('sets the `backgroundColor`', () => {
+      text.setTextTransform(textTransform)
+
+      expect(text.textTransform).toEqual(textTransform)
     })
 
     it('returns the `Text` instance', () => {

--- a/src/mocks/layers/text.ts
+++ b/src/mocks/layers/text.ts
@@ -42,6 +42,7 @@ export const mockTextLayerConfig = (
 
 const MockTextValue = {
   backgroundColor: Color.white,
+  backgroundTransform: 'none',
   border: 'none',
   borderRadius: 0,
   color: Color.black,
@@ -58,10 +59,12 @@ const MockTextValue = {
     x: TextHorizontalPositionValue.center,
     y: TextVerticalPositionValue.center,
   },
+  textTransform: 'none',
 }
 
 export const mockTextOptions = ({
   backgroundColor = MockTextValue.backgroundColor,
+  backgroundTransform = MockTextValue.backgroundTransform,
   border = MockTextValue.border,
   borderRadius = MockTextValue.borderRadius,
   color = MockTextValue.color,
@@ -75,8 +78,10 @@ export const mockTextOptions = ({
   textAlign = MockTextValue.textAlign,
   textDecoration = MockTextValue.textDecoration,
   textPosition = MockTextValue.textPosition,
+  textTransform = MockTextValue.textTransform,
 }: TextOptions = MockTextValue): TextOptions => ({
   backgroundColor,
+  backgroundTransform,
   border,
   borderRadius,
   color,
@@ -90,6 +95,7 @@ export const mockTextOptions = ({
   textAlign,
   textDecoration,
   textPosition,
+  textTransform,
 })
 
 export const mockTextLayer = (): TextLayer => deepMerge({ text: mockTextOptions() }, mockTextLayerConfig())

--- a/src/utils/defaults/html.ts
+++ b/src/utils/defaults/html.ts
@@ -1,28 +1,27 @@
 import {
-  Dimensions,
   HtmlLayer,
   HtmlLayerConfig,
   defaultHtmlOptions,
   defaultPosition,
+  defaultSize,
   defaultTimeline,
   defaultTransitions,
   defaultTrim,
 } from 'constant'
-import { makeDefaultSize } from 'utils/defaults/size'
 import { deepMerge } from 'utils/objects'
 
-export const makeDefaultHtmlLayerConfig = (dimensions: Dimensions): HtmlLayerConfig => {
+export const makeDefaultHtmlLayerConfig = (): HtmlLayerConfig => {
   const defaults = {}
 
-  deepMerge(defaults, defaultPosition, makeDefaultSize(dimensions), defaultTimeline, defaultTransitions, defaultTrim)
+  deepMerge(defaults, defaultPosition, defaultSize, defaultTimeline, defaultTransitions, defaultTrim)
 
   return defaults
 }
 
-export const makeDefaultHtmlLayer = (dimensions: Dimensions): HtmlLayer => {
+export const makeDefaultHtmlLayer = (): HtmlLayer => {
   const defaults: HtmlLayer = { html: defaultHtmlOptions }
 
-  deepMerge(defaults, makeDefaultHtmlLayerConfig(dimensions))
+  deepMerge(defaults, makeDefaultHtmlLayerConfig())
 
   return defaults
 }

--- a/src/utils/defaults/text.ts
+++ b/src/utils/defaults/text.ts
@@ -22,6 +22,7 @@ export const makeDefaultTextLayerConfig = (): TextLayerConfig => {
 
 export const makeDefaultTextOptions = (): TextOptions => ({
   backgroundColor: Color.transparent,
+  backgroundTransform: 'none',
   border: 'none',
   borderRadius: 0,
   color: Color.white,
@@ -35,6 +36,7 @@ export const makeDefaultTextOptions = (): TextOptions => ({
   textAlign: TextAlignValue.left,
   textDecoration: 'none',
   textPosition: null,
+  textTransform: 'none',
 })
 
 export const makeDefaultTextLayer = (): TextLayer => {

--- a/src/utils/validation/layers/text/index.ts
+++ b/src/utils/validation/layers/text/index.ts
@@ -93,6 +93,7 @@ export const validateText: LayerValidator<TextLayer> = ({
   layer: {
     text: {
       backgroundColor,
+      backgroundTransform,
       border,
       borderRadius,
       color,
@@ -106,6 +107,7 @@ export const validateText: LayerValidator<TextLayer> = ({
       textAlign,
       textDecoration,
       textPosition,
+      textTransform,
     },
   },
 }) => {
@@ -116,6 +118,14 @@ export const validateText: LayerValidator<TextLayer> = ({
       callerName,
       ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.backgroundColor),
       backgroundColor,
+      PrimitiveType.string
+    )
+  )
+  errors.push(
+    validateValueIsOfType(
+      callerName,
+      ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.backgroundTransform),
+      backgroundTransform,
       PrimitiveType.string
     )
   )
@@ -195,6 +205,14 @@ export const validateText: LayerValidator<TextLayer> = ({
     )
   )
   errors.push(validateTextPosition(callerName, textPosition))
+  errors.push(
+    validateValueIsOfType(
+      callerName,
+      ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.textTransform),
+      textTransform,
+      PrimitiveType.string
+    )
+  )
 
   return errors.filter(filterUndefined)
 }

--- a/src/utils/validation/layers/text/text.test.ts
+++ b/src/utils/validation/layers/text/text.test.ts
@@ -33,6 +33,7 @@ describe('validateText', () => {
   const textOptions = mockTextOptions()
   const {
     backgroundColor,
+    backgroundTransform,
     border,
     borderRadius,
     color,
@@ -46,6 +47,7 @@ describe('validateText', () => {
     textAlign,
     textDecoration,
     textPosition,
+    textTransform,
   } = textOptions
 
   beforeEach(() => {
@@ -64,12 +66,19 @@ describe('validateText', () => {
       },
     })
 
-    expect(validateValueIsOfTypeSpy).toHaveBeenCalledTimes(10)
+    expect(validateValueIsOfTypeSpy).toHaveBeenCalledTimes(12)
 
     expect(validateValueIsOfTypeSpy).toHaveBeenCalledWith(
       callerName,
       ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.backgroundColor),
       backgroundColor,
+      PrimitiveType.string
+    )
+
+    expect(validateValueIsOfTypeSpy).toHaveBeenCalledWith(
+      callerName,
+      ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.backgroundTransform),
+      backgroundTransform,
       PrimitiveType.string
     )
 
@@ -133,6 +142,13 @@ describe('validateText', () => {
       callerName,
       ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.textDecoration),
       textDecoration,
+      PrimitiveType.string
+    )
+
+    expect(validateValueIsOfTypeSpy).toHaveBeenCalledWith(
+      callerName,
+      ValidationErrorText.SUB_FIELD(LayerKey.text, TextKey.textTransform),
+      textTransform,
       PrimitiveType.string
     )
   })

--- a/src/utils/video/compositions/compositions.test.ts
+++ b/src/utils/video/compositions/compositions.test.ts
@@ -70,7 +70,7 @@ describe('setLayerDefaults', () => {
   })
 
   describe('html', () => {
-    const defaultHtmlLayer = makeDefaultHtmlLayer(dimensions)
+    const defaultHtmlLayer = makeDefaultHtmlLayer()
 
     it('sets the correct layer defaults when no options or config are provided', () => {
       expect(setLayerDefaults(dimensions, LayerType.html, {}, {})).toEqual(defaultHtmlLayer)

--- a/src/utils/video/compositions/index.ts
+++ b/src/utils/video/compositions/index.ts
@@ -60,7 +60,7 @@ export const setLayerDefaults = <Layer>(
   const layerDefaults: Record<LayerType, ComposableLayer> = {
     [LayerType.audio]: makeDefaultAudioLayer(),
     [LayerType.filter]: defaultFilterLayer,
-    [LayerType.html]: makeDefaultHtmlLayer(defaultDimensions),
+    [LayerType.html]: makeDefaultHtmlLayer(),
     [LayerType.image]: makeDefaultImageLayer(),
     [LayerType.lottie]: makeDefaultLottieLayer(),
     [LayerType.sequence]: makeDefaultSequenceLayer(),


### PR DESCRIPTION
```javascript
await composition.addHtml({
    selector: "h1",
    url: "https://docs.editframe.com/",
    withTransparentBackground: false,
  });
  ```

https://user-images.githubusercontent.com/4702409/172487582-9add8548-e7de-4180-9f56-ccb20f4161cc.mp4

```javascript
 composition.addHtml({
   url: "https://docs.editframe.com/layer-types/add-video",
   withTransparentBackground: false,
 });
```

https://user-images.githubusercontent.com/4702409/172487730-8584d8e3-0331-4ff6-b8a6-ffe2656cf62c.mp4


