### PR TITLE
fix: trigger dev backend release on merge into dev

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -1,0 +1,70 @@
+name: Release Dev
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: act10ns/slack@v1
+        with:
+          status: starting
+          channel: '#ci-cd'
+          config: .github/config/slack.yml
+        if: always()
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - run: yarn lint
+      - run: yarn test
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#ci-cd'
+          config: .github/config/slack.yml
+        if: always()
+
+  release_dev:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: act10ns/slack@v1
+        with:
+          status: starting
+          channel: '#ci-cd'
+          config: .github/config/slack.yml
+        if: always()
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - name: HTTP Request Action
+        uses: fjogeleit/http-request-action@v1.9.2
+        with:
+          url: 'https://forge.laravel.com/servers/526578/sites/1537210/deploy/http?token=MWzb3cZaVQ7vIvRuunnf1RujUrAKaKCSfd7bmdKi'
+          method: 'GET'
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#ci-cd'
+          config: .github/config/slack.yml
+        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ dev ]
   pull_request:
     branches: [ dev ]
 


### PR DESCRIPTION
* removes the current `test` workflow from running on `dev` pushes
* adds new `release_dev` workflow to run on `dev` pushes that does the same thing as `release`, except instead of running `semantic release`, it sends a `GET` to the deploy dev webhook