### PR TITLE
replace 'node:timers/promises' with 'delay'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,14 @@ on:
 
 jobs:
   test:
+    name: Test on Node.js v${{ matrix.node }}
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    strategy:
+      matrix:
+        node: [14, 16]
     steps:
       - uses: act10ns/slack@v1
         with:
@@ -18,9 +22,9 @@ jobs:
           config: .github/config/slack.yml
         if: always()
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node }}
           cache: 'yarn'
       - run: yarn install
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "camelcase-keys": "^7.0.2",
     "chalk": "^4",
     "cross-fetch": "^3.1.5",
+    "delay": "^5.0.0",
     "find-process": "^1.4.7",
     "form-data": "^3.0.0",
     "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,10 @@
   "engines": {
     "node": "14 - 16"
   },
-  "os": ["darwin", "linux"],
+  "os": [
+    "darwin",
+    "linux"
+  ],
   "files": [
     "dist",
     "README.md"

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "typescript": "^4.5.5"
   },
   "engines": {
-    "node": ">=10.15.3",
-    "npm": ">=5"
+    "node": "14 - 16"
   },
+  "os": ["darwin", "linux"],
   "files": [
     "dist",
     "README.md"

--- a/src/features/videos/composition/index.ts
+++ b/src/features/videos/composition/index.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch'
+import delay from 'delay'
 import { Readable } from 'node:stream'
-import { setTimeout } from 'node:timers/promises'
 import open from 'open'
 import ora from 'ora'
 import prettyMilliseconds from 'pretty-ms'
@@ -683,7 +683,7 @@ export class Composition implements CompositionInterface {
         let streamResponse = await fetch(video.streamUrl)
 
         while (streamResponse.status !== 200) {
-          await setTimeout(pollDelay)
+          await delay(pollDelay)
 
           streamResponse = await fetch(video.streamUrl)
         }

--- a/src/features/videos/index.ts
+++ b/src/features/videos/index.ts
@@ -1,5 +1,5 @@
+import delay from 'delay'
 import FormData from 'form-data'
-import { setTimeout } from 'node:timers/promises'
 
 import {
   ApiInterface,
@@ -81,7 +81,7 @@ export class Videos {
       let video = await getVideo()
 
       while (waitUntilEncodingComplete && !video.isFailed && !video.isReady) {
-        await setTimeout(pollDelay)
+        await delay(pollDelay)
 
         video = await getVideo()
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,11 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
- add node.js v14 to the 'test' github actions workflow
- replace 'node:timers/promises' with 'delay
- support only node.js versions 14 - 16 in `package.json.engines`
    - as per [node.js releases](https://nodejs.org/en/about/releases/), 'Production applications should only use Active LTS or Maintenance LTS releases'. currently, active lts is v16 and maintenance lts is v14
- support only macos and linux in `package.json.os`